### PR TITLE
New: update notification

### DIFF
--- a/IntuneWinAppUtilGUI.psd1
+++ b/IntuneWinAppUtilGUI.psd1
@@ -24,6 +24,8 @@
 - Improved: Live Source/Output path length indicators.
 - Improved: On Run, warns if the longest file path under Source exceeds Windows limits, showing the longest path found.
 - Improved: Added UI note clarifying that Source path length is indicative and final check runs at packaging time.
+- Improved: Optional update check against PowerShell Gallery with UI banner.
+- Improved: Added -ShowVersion / -ForceUpdateBanner switches for update-banner testing.
 '@
         }
     }

--- a/IntuneWinAppUtilGUI.psd1
+++ b/IntuneWinAppUtilGUI.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule           = 'IntuneWinAppUtilGUI.psm1'
-    ModuleVersion        = '1.0.6'
+    ModuleVersion        = '1.0.7'
     GUID                 = '7db79126-1b57-48d2-970a-4795692dfcfc'
     Author               = 'Giovanni Solone'
     Description          = 'GUI wrapper for IntuneWinAppUtil.exe with config file support and WPF interface.'
@@ -21,16 +21,9 @@
             LicenseUri   = 'https://opensource.org/licenses/MIT'
             IconUri      = 'https://raw.githubusercontent.com/gioxx/IntuneWinAppUtilGUI/main/Assets/icon.png'
             ReleaseNotes = @'
-- Bugfix: Delisted 1.0.4 from PowerShell Gallery and added again Show-IntuneWinAppUtilGUI to available commands.
-- Bugfix: Removed any reference to ZIP uploads as setup files.
-- Bugfix: Fixed PS 5.1 incompatibility in relative-path resolution ([System.IO.Path]::GetRelativePath is PS 7+).
-- Bugfix: Final filename (of IntuneWin package) is proposed also if AppVersion is not specified in Invoke-AppDeployToolkit.ps1.
-- Improved: Code cleanup, removed redundant GitHub download logic; refactoring.
-- Improved: Validates setup file existence and type.
-- Improved: Tries to create output folder when missing.
-- Improved: Ensures exactly one ".intunewin" extension on output.
-- Improved: If Source folder is not specified, it is inferred from Setup file.
-- Improved: Added more inline comments for maintainability.
+- Improved: Live Source/Output path length indicators.
+- Improved: On Run, warns if the longest file path under Source exceeds Windows limits, showing the longest path found.
+- Improved: Added UI note clarifying that Source path length is indicative and final check runs at packaging time.
 '@
         }
     }

--- a/Private/Get-PowerShellGalleryModuleVersion.ps1
+++ b/Private/Get-PowerShellGalleryModuleVersion.ps1
@@ -1,0 +1,72 @@
+function Get-PowerShellGalleryModuleVersion {
+    <#
+    .SYNOPSIS
+    Returns the latest module version from PowerShell Gallery.
+    .PARAMETER ModuleName
+    The module name to query.
+    .PARAMETER TimeoutSeconds
+    Request timeout in seconds.
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $ModuleName,
+        [Parameter()][int] $TimeoutSeconds = 10,
+        [switch] $Detailed
+    )
+
+    try {
+        $lastError = $null
+        if (Get-Command -Name Find-Module -ErrorAction SilentlyContinue) {
+            try {
+                $galleryModule = Find-Module -Name $ModuleName -Repository PSGallery -ErrorAction Stop
+                if ($galleryModule -and $galleryModule.Version) {
+                    $latest = [version]$galleryModule.Version
+                    return $Detailed ? [PSCustomObject]@{ Latest = $latest; Error = $null } : $latest
+                }
+            } catch {
+                $lastError = $_.Exception.Message
+                # fall back to OData endpoint below
+            }
+        }
+
+        try {
+            $tls12 = [Net.SecurityProtocolType]::Tls12
+            [Net.ServicePointManager]::SecurityProtocol = $tls12 -bor [Net.ServicePointManager]::SecurityProtocol
+        } catch { }
+
+        $url = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='$ModuleName'"
+        $client = New-Object System.Net.Http.HttpClient
+        $client.Timeout = [TimeSpan]::FromSeconds($TimeoutSeconds)
+
+        $resp = $client.GetAsync($url).Result
+        if (-not $resp.IsSuccessStatusCode) {
+            $lastError = "HTTP $($resp.StatusCode)"
+            return $Detailed ? [PSCustomObject]@{ Latest = $null; Error = $lastError } : $null
+        }
+
+        $content = $resp.Content.ReadAsStringAsync().Result
+        if (-not $content) {
+            $lastError = "Empty response"
+            return $Detailed ? [PSCustomObject]@{ Latest = $null; Error = $lastError } : $null
+        }
+
+        $xml = [xml]$content
+        $versions = @()
+        foreach ($entry in $xml.feed.entry) {
+            $ver = $entry.properties.Version
+            if ($ver) { $versions += [version]$ver }
+        }
+        if ($versions.Count -eq 0) {
+            $lastError = "No versions found"
+            return $Detailed ? [PSCustomObject]@{ Latest = $null; Error = $lastError } : $null
+        }
+        $latest = ($versions | Sort-Object -Descending | Select-Object -First 1)
+        return $Detailed ? [PSCustomObject]@{ Latest = $latest; Error = $null } : $latest
+    } catch {
+        $msg = $_.Exception.Message
+        return $Detailed ? [PSCustomObject]@{ Latest = $null; Error = $msg } : $null
+    } finally {
+        if ($client) { $client.Dispose() }
+    }
+}

--- a/Private/PathLengthHelpers.ps1
+++ b/Private/PathLengthHelpers.ps1
@@ -1,0 +1,77 @@
+function Get-MaxFilePathInfo {
+    <#
+    .SYNOPSIS
+    Returns the longest full file path length under a root directory.
+    .DESCRIPTION
+    Enumerates files recursively and returns the maximum FullName length and the path.
+    If no files are found, returns the root path and its length.
+    .PARAMETER RootPath
+    The root directory to scan.
+    .OUTPUTS
+    PSCustomObject with Length and Path.
+    #>
+
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string] $RootPath)
+
+    try {
+        $maxLen = 0
+        $maxPath = $null
+        $foundAny = $false
+
+        foreach ($item in Get-ChildItem -Path $RootPath -Recurse -Force -File -ErrorAction SilentlyContinue) {
+            $len = $item.FullName.Length
+            if ($len -gt $maxLen) {
+                $maxLen = $len
+                $maxPath = $item.FullName
+            }
+            $foundAny = $true
+        }
+
+        if (-not $foundAny) {
+            $maxLen = $RootPath.Length
+            $maxPath = $RootPath
+        }
+
+        return [PSCustomObject]@{
+            Length = $maxLen
+            Path   = $maxPath
+        }
+    } catch {
+        return $null
+    }
+}
+
+function Update-PathLengthIndicator {
+    <#
+    .SYNOPSIS
+    Updates a TextBlock with path length info and warning color.
+    .PARAMETER PathText
+    The path text to measure.
+    .PARAMETER Indicator
+    The TextBlock to update.
+    .PARAMETER Limit
+    The max length threshold.
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter()][AllowEmptyString()][string] $PathText,
+        [Parameter(Mandatory)][System.Windows.Controls.TextBlock] $Indicator,
+        [Parameter(Mandatory)][int] $Limit
+    )
+
+    if (-not $Indicator) { return }
+    $len = if ($PathText) { $PathText.Length } else { 0 }
+    if ($len -gt 0) {
+        $Indicator.Visibility = [System.Windows.Visibility]::Visible
+        $Indicator.Text = "Path length: $len/$Limit"
+        $Indicator.Foreground = if ($len -gt $Limit) {
+            [System.Windows.Media.Brushes]::Red
+        } else {
+            [System.Windows.Media.Brushes]::Gray
+        }
+    } else {
+        $Indicator.Visibility = [System.Windows.Visibility]::Collapsed
+    }
+}

--- a/Public/Show-IntuneWinAppUtilGui.ps1
+++ b/Public/Show-IntuneWinAppUtilGui.ps1
@@ -3,7 +3,9 @@
 function Show-IntuneWinAppUtilGUI {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $false, HelpMessage = "Show diagnostic information")][switch] $Diag
+        [Parameter(Mandatory = $false, HelpMessage = "Show diagnostic information")][switch] $Diag,
+        [Parameter(Mandatory = $false, HelpMessage = "Show installed and latest module versions")][switch] $ShowVersion,
+        [Parameter(Mandatory = $false, HelpMessage = "Force update banner for testing")][switch] $ForceUpdateBanner
     )
 
     $moduleRoot   = Split-Path -Path $PSScriptRoot -Parent
@@ -76,6 +78,7 @@ function Show-IntuneWinAppUtilGUI {
     $OutputFolder    = $window.FindName("OutputFolder")
     $SourceFolderPathLength = $window.FindName("SourceFolderPathLength")
     $OutputFolderPathLength = $window.FindName("OutputFolderPathLength")
+    $UpdateAvailableText = $window.FindName("UpdateAvailableText")
 
     $ToolPathBox     = $window.FindName("ToolPathBox")
     $ToolVersionText = $window.FindName("ToolVersionText")
@@ -105,6 +108,8 @@ function Show-IntuneWinAppUtilGUI {
         Update-PathLengthIndicator -PathText $SourceFolder.Text -Indicator $SourceFolderPathLength -Limit $PathLengthLimit
     })
 
+    $updateCheckEnabled = $true
+
     # Preload config.json if it exists
     if (Test-Path $configPath) {
         try {
@@ -112,6 +117,9 @@ function Show-IntuneWinAppUtilGUI {
             if ($cfg.ToolPath -and (Test-Path $cfg.ToolPath)) {
                 $ToolPathBox.Text = $cfg.ToolPath
                 Show-ToolVersion -Path $cfg.ToolPath -Target $ToolVersionText
+            }
+            if ($null -ne $cfg.UpdateCheckEnabled) {
+                $updateCheckEnabled = [bool]$cfg.UpdateCheckEnabled
             }
         } catch {}
     }
@@ -127,6 +135,78 @@ function Show-IntuneWinAppUtilGUI {
             $dialog.Dispose()
         }
     })
+
+    $updateCheckJob = $null
+    $updateCheckTimer = $null
+
+    $shouldCheckUpdates = ($updateCheckEnabled -or $ShowVersion) -and $UpdateAvailableText
+
+    if ($shouldCheckUpdates) {
+        $currentVersion = $MyInvocation.MyCommand.Module.Version
+        if ($ForceUpdateBanner) { $currentVersion = [version]'1.0.0' }
+        $modulePath = $MyInvocation.MyCommand.Module.Path
+        $moduleName = 'IntuneWinAppUtilGUI'
+        $timeoutSeconds = 10
+
+        $updateCheckJob = Start-Job -ArgumentList $modulePath, $moduleName, $currentVersion, $timeoutSeconds, [bool]$ShowVersion -ScriptBlock {
+            param($modulePath, $moduleName, $currentVersion, $timeoutSeconds, $showVersion)
+            $moduleRoot = Split-Path $modulePath -Parent
+            $helperPath = Join-Path $moduleRoot 'Private\Get-PowerShellGalleryModuleVersion.ps1'
+            if (Test-Path $helperPath) {
+                . $helperPath
+            } else {
+                if ($showVersion) {
+                    return [PSCustomObject]@{
+                        Current = $currentVersion
+                        Latest  = $null
+                        Error   = "Helper not found: $helperPath"
+                    }
+                }
+                return $null
+            }
+            $result = Get-PowerShellGalleryModuleVersion -ModuleName $moduleName -TimeoutSeconds $timeoutSeconds -Detailed
+            $latest = $result.Latest
+            $errMsg = $result.Error
+            if ($showVersion) {
+                return [PSCustomObject]@{
+                    Current = $currentVersion
+                    Latest  = $latest
+                    Error   = $errMsg
+                }
+            }
+            if ($latest -and ($latest -gt $currentVersion)) { return $latest }
+        }
+
+        $updateCheckTimer = New-Object System.Windows.Threading.DispatcherTimer
+        $updateCheckTimer.Interval = [TimeSpan]::FromMilliseconds(300)
+        $updateCheckTimer.Add_Tick({
+            if (-not $updateCheckJob) { $updateCheckTimer.Stop(); return }
+            if ($updateCheckJob.State -in @('Completed','Failed','Stopped')) {
+                $updateCheckTimer.Stop()
+                $latest = $null
+                try { $latest = Receive-Job $updateCheckJob -ErrorAction SilentlyContinue } catch { }
+                try { Remove-Job $updateCheckJob -Force -ErrorAction SilentlyContinue } catch { }
+                $updateCheckJob = $null
+
+                if ($ForceUpdateBanner) {
+                    $UpdateAvailableText.Text = "Update available: $($latest.Latest) (run 'Update-Module IntuneWinAppUtilGUI' in your PowerShell session)"
+                    $UpdateAvailableText.Visibility = [System.Windows.Visibility]::Visible
+                } elseif ($ShowVersion) {
+                    $latestText = if ($latest -and $latest.Latest) { $latest.Latest } else { 'unknown' }
+                    if ($latest -and $latest.Error) {
+                        $UpdateAvailableText.Text = "Installed: $($latest.Current) | Latest: $latestText (error: $($latest.Error))"
+                    } else {
+                        $UpdateAvailableText.Text = "Installed: $($latest.Current) | Latest: $latestText"
+                    }
+                    $UpdateAvailableText.Visibility = [System.Windows.Visibility]::Visible
+                } elseif ($latest -is [version]) {
+                    $UpdateAvailableText.Text = "Update available: $latest (run 'Update-Module IntuneWinAppUtilGUI' in your PowerShell session)"
+                    $UpdateAvailableText.Visibility = [System.Windows.Visibility]::Visible
+                }
+            }
+        })
+        $updateCheckTimer.Start()
+    }
 
     # Browse for Setup File
     $BrowseSetup.Add_Click({
@@ -456,10 +536,15 @@ function Show-IntuneWinAppUtilGUI {
     # When the window is closed, save the ToolPath to config.json
     $window.Add_Closed({
         try {
+            if ($updateCheckTimer) { $updateCheckTimer.Stop() }
+            if ($updateCheckJob) { Remove-Job $updateCheckJob -Force -ErrorAction SilentlyContinue }
             if (-not (Test-Path (Split-Path $configPath))) {
                 New-Item -Path (Split-Path $configPath) -ItemType Directory -Force | Out-Null
             }
-            $cfg = @{ ToolPath = $ToolPathBox.Text.Trim() }
+            $cfg = @{
+                ToolPath = $ToolPathBox.Text.Trim()
+                UpdateCheckEnabled = $updateCheckEnabled
+            }
             $cfg | ConvertTo-Json | Set-Content $configPath -Encoding UTF8
         } catch { }
     })

--- a/Public/Show-IntuneWinAppUtilGui.ps1
+++ b/Public/Show-IntuneWinAppUtilGui.ps1
@@ -21,11 +21,13 @@ function Show-IntuneWinAppUtilGUI {
     if ([System.Threading.Thread]::CurrentThread.GetApartmentState() -ne 'STA') {
         $modulePath = $MyInvocation.MyCommand.Module.Path
         $shell = if ($PSVersionTable.PSEdition -eq 'Core') { 'pwsh' } else { 'powershell' }
+        $cmd = "Import-Module `"$modulePath`"; Show-IntuneWinAppUtilGUI"
+        if ($PSBoundParameters.ContainsKey('Debug')) { $cmd += " -Debug" }
         Start-Process $shell -ArgumentList @(
             '-NoProfile',
             '-STA',
-            '-Command', "Import-Module `"$modulePath`"; Show-IntuneWinAppUtilGUI"
-        ) | Out-Null
+            '-Command', $cmd
+        ) -NoNewWindow | Out-Null
         return
     }
 
@@ -72,6 +74,8 @@ function Show-IntuneWinAppUtilGUI {
     $SourceFolder    = $window.FindName("SourceFolder")
     $SetupFile       = $window.FindName("SetupFile")
     $OutputFolder    = $window.FindName("OutputFolder")
+    $SourceFolderPathLength = $window.FindName("SourceFolderPathLength")
+    $OutputFolderPathLength = $window.FindName("OutputFolderPathLength")
 
     $ToolPathBox     = $window.FindName("ToolPathBox")
     $ToolVersionText = $window.FindName("ToolVersionText")
@@ -88,11 +92,17 @@ function Show-IntuneWinAppUtilGUI {
     $ClearButton     = $window.FindName("ClearButton")
     $ExitButton      = $window.FindName("ExitButton")
 
+    $PathLengthLimit = 260
+
+    Update-PathLengthIndicator -PathText $SourceFolder.Text -Indicator $SourceFolderPathLength -Limit $PathLengthLimit
+    Update-PathLengthIndicator -PathText $OutputFolder.Text -Indicator $OutputFolderPathLength -Limit $PathLengthLimit
+
     # When user types/pastes the source path manually, try to auto-suggest the setup file if found.
     $SourceFolder.Add_TextChanged({
         param($evtSender, $e)
         $src = $SourceFolder.Text.Trim()
         if ($src) { Set-SetupFromSource -SourcePath $src -SetupFileControl $SetupFile -FinalFilenameControl $FinalFilename }
+        Update-PathLengthIndicator -PathText $SourceFolder.Text -Indicator $SourceFolderPathLength -Limit $PathLengthLimit
     })
 
     # Preload config.json if it exists
@@ -112,7 +122,6 @@ function Show-IntuneWinAppUtilGUI {
         try {
             if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
                 $SourceFolder.Text = $dialog.SelectedPath
-                Set-SetupFromSource -SourcePath $dialog.SelectedPath -SetupFileControl $SetupFile -FinalFilenameControl $FinalFilename
             }
         } finally {
             $dialog.Dispose()
@@ -159,6 +168,11 @@ function Show-IntuneWinAppUtilGUI {
         } finally {
             $dialog.Dispose()
         }
+    })
+
+    $OutputFolder.Add_TextChanged({
+        param($evtSender, $e)
+        Update-PathLengthIndicator -PathText $OutputFolder.Text -Indicator $OutputFolderPathLength -Limit $PathLengthLimit
     })
 
     # Browse for IntuneWinAppUtil.exe
@@ -278,6 +292,27 @@ function Show-IntuneWinAppUtilGUI {
         } catch {
             [System.Windows.MessageBox]::Show("Invalid path format: $($_.Exception.Message)", "Error", "OK", "Error")
             return
+        }
+
+        $pathWarnings = @()
+        if ($c.Length -gt $PathLengthLimit) { $pathWarnings += "Source folder: $($c.Length)/$PathLengthLimit" }
+        $maxFileInfo = Get-MaxFilePathInfo -RootPath $c
+        if ($null -ne $maxFileInfo -and $maxFileInfo.Length -gt $PathLengthLimit) {
+            $pathWarnings += "Max file path in source: $($maxFileInfo.Length)/$PathLengthLimit"
+            $pathWarnings += "Longest path: $($maxFileInfo.Path)"
+        }
+        if ($o.Length -gt $PathLengthLimit) { $pathWarnings += "Output folder: $($o.Length)/$PathLengthLimit" }
+        if ($pathWarnings.Count -gt 0) {
+            $msg = "One or more paths exceed $PathLengthLimit characters.`n`n" +
+                   ($pathWarnings -join "`n") +
+                   "`n`nThis can cause IntuneWinAppUtil to fail on Windows.`nProceed anyway?"
+            $confirm = [System.Windows.MessageBox]::Show(
+                $msg,
+                "Path length warning",
+                [System.Windows.MessageBoxButton]::YesNo,
+                [System.Windows.MessageBoxImage]::Warning
+            )
+            if ($confirm -ne [System.Windows.MessageBoxResult]::Yes) { return }
         }
 
         # IntuneWinAppUtil.exe path check (or initialize/download if not set)

--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ This tool simplifies the packaging of Win32 apps for Microsoft Intune by providi
 - **Auto-download** of the latest version of `IntuneWinAppUtil.exe` from GitHub (optional).
 - It detects the use of PSAppDeployToolkit and automatically proposes executable file and final IntuneWin package name.
 - Sanitizes invalid characters from the output filename.
+- Live path length indicator for Source/Output folders, with a final max-path check at Run time.
+- Optional update check on startup with a non-blocking UI banner.
 
 ---
 
 ## 🧰 Requirements
 
-- Windows 10 or later.
-- PowerShell 5.1 or higher.
+- Windows 10 or later (Windows 11 is recommended).
+- PowerShell 5.1 or higher (PowerShell 7 is recommended).
 - .NET Framework 4.7.2 or higher (usually already installed on supported systems).
 
 ---
@@ -65,7 +67,7 @@ Show-IntuneWinAppUtilGUI
 | Field                  | Required | Description |
 |------------------------|----------|-------------|
 | **Source Folder (-c)** | ✅ Yes   | The root folder containing your setup file. |
-| **Setup File (-s)**    | ✅ Yes   | The installer (EXE, MSI, or ZIP). If in same folder, only the filename is shown. |
+| **Setup File (-s)**    | ✅ Yes   | The installer (EXE or MSI). If in same folder, only the filename is shown. |
 | **Output Folder (-o)** | ✅ Yes   | Where the `.intunewin` package will be created. |
 | **IntuneWinAppUtil**   | ✅ Yes\* | You can specify the path manually or let the GUI download the latest version automatically. |
 | **Final Filename**     | Optional | Renames the generated `.intunewin` file. Invalid characters are removed automatically. |
@@ -84,6 +86,7 @@ Show-IntuneWinAppUtilGUI
 
 - It stores only the `ToolPath` so it can be reused at next launch.
 - This file is updated when the GUI closes.
+- Optional: `UpdateCheckEnabled` (boolean) to enable/disable the update check banner.
 
 ---
 
@@ -104,6 +107,8 @@ If the path to `IntuneWinAppUtil.exe` is not provided:
 - Press **ENTER** to run the packaging when you are ready.
 - A small tooltip message at the bottom of the GUI provides quick usage hints.
 - Clear and Exit buttons are provided to reset inputs or close the app manually.
+- Use `Show-IntuneWinAppUtilGUI -ShowVersion` to display installed/latest versions for testing.
+- Use `Show-IntuneWinAppUtilGUI -ForceUpdateBanner` to simulate an update banner.
 
 ---
 

--- a/UI/UI.xaml
+++ b/UI/UI.xaml
@@ -53,6 +53,12 @@
                     <TextBox Name="SourceFolder" Grid.Column="0" Margin="0,0,10,0" Padding="4"/>
                     <Button Name="BrowseSource" Content="Browse..." Grid.Column="1" Width="80" Padding="2"/>
                 </Grid>
+                <TextBlock Name="SourceFolderPathLength"
+                           Text="Path length: 0/260"
+                           Foreground="Gray"
+                           FontSize="11"
+                           Margin="0,4,0,0"
+                           Visibility="Collapsed"/>
             </StackPanel>
 
             <!-- Setup File -->
@@ -86,6 +92,12 @@
                     <TextBox Name="OutputFolder" Grid.Column="0" Margin="0,0,10,0" Padding="4"/>
                     <Button Name="BrowseOutput" Content="Browse..." Grid.Column="1" Width="80" Padding="2"/>
                 </Grid>
+                <TextBlock Name="OutputFolderPathLength"
+                           Text="Path length: 0/260"
+                           Foreground="Gray"
+                           FontSize="11"
+                           Margin="0,4,0,0"
+                           Visibility="Collapsed"/>
             </StackPanel>
 
             <!-- Tool Path -->
@@ -149,7 +161,7 @@
 
             <!-- Info tooltip -->
             <TextBlock Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
-            Text="⚠️ Source folder, setup file and output folder are required (*).&#x0a;ℹ️ Final filename is optional and used for renaming the .intunewin file. If not provided, the tool will generate a name based on the source folder.&#x0a;ℹ️ IntuneWinAppUtil Path is also optional. If not provided, the tool will automatically download the latest version from GitHub.&#x0a;&#x0a;Press ESC on the keyboard to close the application.&#x0a;Click on 'Run' button or press ENTER on the keyboard to execute the IntuneWinAppUtil with the provided parameters."
+            Text="⚠️ Source folder, setup file and output folder are required (*).&#x0a;ℹ️ The Source folder path length shown above is indicative; the final check runs at packaging time (Run) and considers the longest file path.&#x0a;ℹ️ Final filename is optional and used for renaming the .intunewin file. If not provided, the tool will generate a name based on the source folder.&#x0a;ℹ️ IntuneWinAppUtil Path is also optional. If not provided, the tool will automatically download the latest version from GitHub.&#x0a;&#x0a;Press ESC on the keyboard to close the application.&#x0a;Click on 'Run' button or press ENTER on the keyboard to execute the IntuneWinAppUtil with the provided parameters."
             Foreground="Gray" FontSize="12" Margin="0,20,0,0" TextWrapping="Wrap"/>
 
             <!-- GitHub Link -->

--- a/UI/UI.xaml
+++ b/UI/UI.xaml
@@ -11,16 +11,24 @@
 
         <!-- ===== Header ===== -->
         <Border DockPanel.Dock="Top" Padding="0,0,0,12">
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                <Image Name="HeaderIcon" Width="28" Height="28" Margin="0,0,8,0"/>
-                <TextBlock Text="IntuneWinAppUtil GUI"
-                           FontSize="24" FontWeight="Bold"
-                           VerticalAlignment="Center"
-                           TextOptions.TextFormattingMode="Ideal"
-                           TextOptions.TextRenderingMode="ClearType"/>
-                <!-- <TextBlock Text="  ·  1.0.0"
-                           FontSize="18" Foreground="Gray"
-                           VerticalAlignment="Center" Margin="6,2,0,0"/> -->
+            <StackPanel Orientation="Vertical">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <Image Name="HeaderIcon" Width="28" Height="28" Margin="0,0,8,0"/>
+                    <TextBlock Text="IntuneWinAppUtil GUI"
+                               FontSize="24" FontWeight="Bold"
+                               VerticalAlignment="Center"
+                               TextOptions.TextFormattingMode="Ideal"
+                               TextOptions.TextRenderingMode="ClearType"/>
+                    <!-- <TextBlock Text="  ·  1.0.0"
+                               FontSize="18" Foreground="Gray"
+                               VerticalAlignment="Center" Margin="6,2,0,0"/> -->
+                </StackPanel>
+                <TextBlock Name="UpdateAvailableText"
+                           Text=""
+                           Foreground="Gray"
+                           FontSize="12"
+                           Margin="36,4,0,0"
+                           Visibility="Collapsed"/>
             </StackPanel>
         </Border>
         <!-- ===== End Header ===== -->


### PR DESCRIPTION
- Add a non-blocking optional update check that shows a UI banner when a newer module is available.
- Introduces two new switches (`-ShowVersion` and `-ForceUpdateBanner`) and an UpdateAvailableText UI element in UI.xaml.
- Adds `Private/Get-PowerShellGalleryModuleVersion.ps1` to query PowerShell Gallery (`Find-Module` with OData fallback) and uses a background job + DispatcherTimer to update the UI without blocking startup.
- Persist UpdateCheckEnabled in config.json and stop/cleanup the timer/job on window close.
- README and module manifest notes updated to document the feature and testing switches.