### PR TITLE
chore(release): prepare 1.0.8

### DIFF
--- a/IntuneWinAppUtilGUI.psd1
+++ b/IntuneWinAppUtilGUI.psd1
@@ -27,6 +27,7 @@
 - Improved: Refreshed the main window layout with a cleaner, modern visual style.
 - Improved: Added in-app Help for launch switches and keyboard shortcuts.
 - Improved: Clarified confirmation popups for exit, download, path warnings and package completion.
+- Fixed: ShowVersion and ForceUpdateBanner now provide immediate feedback in the refreshed header.
 - Improved: Release naming and UI version now align with 1.0.8.
 '@
         }

--- a/IntuneWinAppUtilGUI.psd1
+++ b/IntuneWinAppUtilGUI.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule           = 'IntuneWinAppUtilGUI.psm1'
-    ModuleVersion        = '1.0.7'
+    ModuleVersion        = '1.0.8'
     GUID                 = '7db79126-1b57-48d2-970a-4795692dfcfc'
     Author               = 'Giovanni Solone'
     Description          = 'GUI wrapper for IntuneWinAppUtil.exe with config file support and WPF interface.'
@@ -21,12 +21,9 @@
             LicenseUri   = 'https://opensource.org/licenses/MIT'
             IconUri      = 'https://raw.githubusercontent.com/gioxx/IntuneWinAppUtilGUI/main/Assets/icon.png'
             ReleaseNotes = @'
-- Improved: Live Source/Output path length indicators.
-- Improved: On Run, warns if the longest file path under Source exceeds Windows limits, showing the longest path found.
-- Improved: Added UI note clarifying that Source path length is indicative and final check runs at packaging time.
-- Improved: Optional update check against PowerShell Gallery with UI banner.
-- Improved: Added -ShowVersion / -ForceUpdateBanner switches for update-banner testing.
-- Improved: Consolidated private helpers under IWAPG-Hlp-* naming.
+- Fixed: Retries output rename when the target file is temporarily locked.
+- Improved: Falls back to MSI metadata for PSADT/MSI-based packages when AppName/AppVersion are missing.
+- Improved: Release naming and UI version now align with 1.0.8.
 '@
         }
     }

--- a/IntuneWinAppUtilGUI.psd1
+++ b/IntuneWinAppUtilGUI.psd1
@@ -25,6 +25,8 @@
 - Improved: Falls back to MSI metadata for PSADT/MSI-based packages when AppName/AppVersion are missing.
 - Fixed: Replaced emoji UI glyphs with Windows-version-safe labels.
 - Improved: Refreshed the main window layout with a cleaner, modern visual style.
+- Improved: Added in-app Help for launch switches and keyboard shortcuts.
+- Improved: Clarified confirmation popups for exit, download, path warnings and package completion.
 - Improved: Release naming and UI version now align with 1.0.8.
 '@
         }

--- a/IntuneWinAppUtilGUI.psd1
+++ b/IntuneWinAppUtilGUI.psd1
@@ -23,6 +23,7 @@
             ReleaseNotes = @'
 - Fixed: Retries output rename when the target file is temporarily locked.
 - Improved: Falls back to MSI metadata for PSADT/MSI-based packages when AppName/AppVersion are missing.
+- Fixed: Replaced emoji UI glyphs with Windows-version-safe labels.
 - Improved: Release naming and UI version now align with 1.0.8.
 '@
         }

--- a/IntuneWinAppUtilGUI.psd1
+++ b/IntuneWinAppUtilGUI.psd1
@@ -24,6 +24,7 @@
 - Fixed: Retries output rename when the target file is temporarily locked.
 - Improved: Falls back to MSI metadata for PSADT/MSI-based packages when AppName/AppVersion are missing.
 - Fixed: Replaced emoji UI glyphs with Windows-version-safe labels.
+- Improved: Refreshed the main window layout with a cleaner, modern visual style.
 - Improved: Release naming and UI version now align with 1.0.8.
 '@
         }

--- a/Private/IWAPG-Hlp-Setup.ps1
+++ b/Private/IWAPG-Hlp-Setup.ps1
@@ -49,6 +49,77 @@ function Get-RelativePath {
     }
 }
 
+function Get-MsiPackageMetadata {
+    <#
+    .SYNOPSIS
+    Reads ProductName and ProductVersion from an MSI package.
+    .DESCRIPTION
+    Uses the Windows Installer COM object to inspect the MSI Property table.
+    Returns $null when the file cannot be read or the required values are missing.
+    .PARAMETER MsiPath
+    Full path to the MSI file.
+    .OUTPUTS
+    [pscustomobject] with ProductName and ProductVersion, or $null.
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$MsiPath
+    )
+
+    if (-not (Test-Path $MsiPath)) { return $null }
+
+    $installer = $null
+    $database = $null
+    $views = @()
+
+    try {
+        $fullPath = (Resolve-Path -LiteralPath $MsiPath).Path
+        $installer = New-Object -ComObject WindowsInstaller.Installer
+        $database = $installer.OpenDatabase($fullPath, 0)
+
+        $metadata = [ordered]@{}
+        foreach ($propertyName in @('ProductName', 'ProductVersion')) {
+            $view = $null
+            try {
+                $query = "SELECT `Value` FROM `Property` WHERE `Property`='$propertyName'"
+                $view = $database.OpenView($query)
+                $views += $view
+                $view.Execute()
+                $record = $view.Fetch()
+                if ($record) {
+                    $value = $record.StringData(1)
+                    if (-not [string]::IsNullOrWhiteSpace($value)) {
+                        $metadata[$propertyName] = $value.Trim()
+                    }
+                }
+            } catch {
+                continue
+            }
+        }
+
+        if (-not $metadata.Contains('ProductName') -and -not $metadata.Contains('ProductVersion')) {
+            return $null
+        }
+
+        [pscustomobject]$metadata
+    } catch {
+        return $null
+    } finally {
+        foreach ($view in $views) {
+            if ($view) {
+                try { [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($view) } catch { }
+            }
+        }
+        if ($database) {
+            try { [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($database) } catch { }
+        }
+        if ($installer) {
+            try { [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($installer) } catch { }
+        }
+    }
+}
+
 function Set-SetupFromSource {
     <#
     .SYNOPSIS
@@ -60,6 +131,7 @@ function Set-SetupFromSource {
     - If 'Invoke-AppDeployToolkit.ps1' exists in the same folder, extracts AppName/AppVersion and sets FinalFilenameControl.Text:
         * 'AppName_Version' when both are present;
         * 'AppName' when AppVersion is missing/empty.
+    - If the PSADT metadata is missing, falls back to the first MSI found under SourcePath and uses its ProductName/ProductVersion.
       Filename is sanitized (spaces removed, invalid filename chars replaced with '-').
     - Parsing/IO errors are swallowed.
     .PARAMETER SourcePath
@@ -91,50 +163,77 @@ function Set-SetupFromSource {
         if (Test-Path $maybeRelative) { return }
     }
 
-    # Search for Invoke-AppDeployToolkit.exe
+    # Search for Invoke-AppDeployToolkit.exe first, then fall back to the first MSI in the tree.
     $exeHit = Get-ChildItem -Path $SourcePath -Filter 'Invoke-AppDeployToolkit.exe' -File -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
-    if ($exeHit) {
+    $msiHit = $null
+    if (-not $exeHit) {
+        $msiHit = Get-ChildItem -Path $SourcePath -Filter '*.msi' -File -Recurse -ErrorAction SilentlyContinue |
+            Sort-Object FullName |
+            Select-Object -First 1
+    }
+
+    $selectedHit = if ($exeHit) { $exeHit } else { $msiHit }
+    if ($selectedHit) {
         # Prefer a relative path when the file is inside the source folder
-        $SetupFileControl.Text = Get-RelativePath -BasePath $SourcePath -TargetPath $exeHit.FullName
+        $SetupFileControl.Text = Get-RelativePath -BasePath $SourcePath -TargetPath $selectedHit.FullName
 
         # If FinalFilenameControl already has a value, don't override user's input.
         $finalCurrent = $FinalFilenameControl.Text.Trim()
         if (-not $finalCurrent) {
-            # Look for Invoke-AppDeployToolkit.ps1 in the same folder
-            $ps1Path = Join-Path $exeHit.Directory.FullName 'Invoke-AppDeployToolkit.ps1'
-            if (Test-Path $ps1Path) {
-                try {
-                    $content = Get-Content $ps1Path -Raw
+            try {
+                # Look for Invoke-AppDeployToolkit.ps1 in the same folder when we are dealing with PSADT packages.
+                $appName = $null
+                $appVersion = $null
 
-                    # Support both single and double quotes: AppName = 'X' or AppName = "X"
-                    $appName = $null
-                    $appVersion = $null
-                    if ($content -match '(?m)AppName\s*=\s*[''"]([^''"]+)[''"]') { $appName = $matches[1] }
-                    if ($content -match '(?m)AppVersion\s*=\s*[''"]([^''"]*)[''"]') { $appVersion = $matches[1] }
+                if ($exeHit) {
+                    $ps1Path = Join-Path $exeHit.Directory.FullName 'Invoke-AppDeployToolkit.ps1'
+                    if (Test-Path $ps1Path) {
+                        $content = Get-Content $ps1Path -Raw
 
-                    # Sanitize function: remove spaces, replace invalid filename chars with '-'
-                    function _Sanitize([string]$s) {
-                        if ([string]::IsNullOrWhiteSpace($s)) { return $null }
-                        $noSpaces = ($s -replace '\s+', '')
-                        return ($noSpaces -replace '[\\/:*?"<>|]', '-')
+                        # Support both single and double quotes: AppName = 'X' or AppName = "X"
+                        if ($content -match '(?m)AppName\s*=\s*[''"]([^''"]+)[''"]') { $appName = $matches[1] }
+                        if ($content -match '(?m)AppVersion\s*=\s*[''"]([^''"]*)[''"]') { $appVersion = $matches[1] }
                     }
+                }
 
-                    $cleanName = _Sanitize $appName
-                    $cleanVer = _Sanitize $appVersion
-
-                    # Build proposed filename:
-                    # - If both present: "Name_Version"
-                    # - If version missing/empty but name present: "Name"
-                    if ($cleanName) {
-                        $parts = @($cleanName)
-                        if ($cleanVer) { $parts += $cleanVer }
-                        $FinalFilenameControl.Text = ($parts -join '_')
+                # Fall back to MSI metadata when PSADT metadata is missing or incomplete.
+                if ([string]::IsNullOrWhiteSpace($appName)) {
+                    $msiSource = if ($msiHit) { $msiHit } elseif ($selectedHit.Extension -ieq '.msi') { $selectedHit } else { $null }
+                    if ($msiSource) {
+                        $msiMeta = Get-MsiPackageMetadata -MsiPath $msiSource.FullName
+                        if ($msiMeta) {
+                            if ([string]::IsNullOrWhiteSpace($appName) -and $msiMeta.ProductName) {
+                                $appName = $msiMeta.ProductName
+                            }
+                            if ([string]::IsNullOrWhiteSpace($appVersion) -and $msiMeta.ProductVersion) {
+                                $appVersion = $msiMeta.ProductVersion
+                            }
+                        }
                     }
-                    # else: do nothing when AppName is missing
                 }
-                catch {
-                    # fail silently
+
+                # Sanitize function: remove spaces, replace invalid filename chars with '-'
+                function _Sanitize([string]$s) {
+                    if ([string]::IsNullOrWhiteSpace($s)) { return $null }
+                    $noSpaces = ($s -replace '\s+', '')
+                    return ($noSpaces -replace '[\\/:*?"<>|]', '-')
                 }
+
+                $cleanName = _Sanitize $appName
+                $cleanVer = _Sanitize $appVersion
+
+                # Build proposed filename:
+                # - If both present: "Name_Version"
+                # - If version missing/empty but name present: "Name"
+                if ($cleanName) {
+                    $parts = @($cleanName)
+                    if ($cleanVer) { $parts += $cleanVer }
+                    $FinalFilenameControl.Text = ($parts -join '_')
+                }
+                # else: do nothing when AppName is missing
+            }
+            catch {
+                # fail silently
             }
         }
     }

--- a/Private/IWAPG-Hlp-Setup.ps1
+++ b/Private/IWAPG-Hlp-Setup.ps1
@@ -82,7 +82,7 @@ function Get-MsiPackageMetadata {
         foreach ($propertyName in @('ProductName', 'ProductVersion')) {
             $view = $null
             try {
-                $query = "SELECT `Value` FROM `Property` WHERE `Property`='$propertyName'"
+                $query = 'SELECT `Value` FROM `Property` WHERE `Property`=''' + $propertyName + ''''
                 $view = $database.OpenView($query)
                 $views += $view
                 $view.Execute()
@@ -163,14 +163,15 @@ function Set-SetupFromSource {
         if (Test-Path $maybeRelative) { return }
     }
 
-    # Search for Invoke-AppDeployToolkit.exe first, then fall back to the first MSI in the tree.
+    # Search for Invoke-AppDeployToolkit.exe first, and keep an MSI candidate for metadata fallback.
     $exeHit = Get-ChildItem -Path $SourcePath -Filter 'Invoke-AppDeployToolkit.exe' -File -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
-    $msiHit = $null
-    if (-not $exeHit) {
-        $msiHit = Get-ChildItem -Path $SourcePath -Filter '*.msi' -File -Recurse -ErrorAction SilentlyContinue |
-            Sort-Object FullName |
-            Select-Object -First 1
-    }
+    $msiHit = Get-ChildItem -Path $SourcePath -Filter '*.msi' -File -Recurse -ErrorAction SilentlyContinue |
+        Sort-Object @{
+            Expression = {
+                if ($_.FullName -match '\\Files\\') { 0 } else { 1 }
+            }
+        }, FullName |
+        Select-Object -First 1
 
     $selectedHit = if ($exeHit) { $exeHit } else { $msiHit }
     if ($selectedHit) {
@@ -190,9 +191,9 @@ function Set-SetupFromSource {
                     if (Test-Path $ps1Path) {
                         $content = Get-Content $ps1Path -Raw
 
-                        # Support both single and double quotes: AppName = 'X' or AppName = "X"
-                        if ($content -match '(?m)AppName\s*=\s*[''"]([^''"]+)[''"]') { $appName = $matches[1] }
-                        if ($content -match '(?m)AppVersion\s*=\s*[''"]([^''"]*)[''"]') { $appVersion = $matches[1] }
+                        # Support common PSADT forms such as $appName, $adtSession.AppName, and direct AppName assignments.
+                        if ($content -match '(?im)(?:\$[\w.]+\.)?AppName\s*=\s*[''"]([^''"]*)[''"]') { $appName = $matches[1] }
+                        if ($content -match '(?im)(?:\$[\w.]+\.)?AppVersion\s*=\s*[''"]([^''"]*)[''"]') { $appVersion = $matches[1] }
                     }
                 }
 

--- a/Public/Show-IntuneWinAppUtilGui.ps1
+++ b/Public/Show-IntuneWinAppUtilGui.ps1
@@ -94,6 +94,7 @@ function Show-IntuneWinAppUtilGUI {
     $BrowseTool      = $window.FindName("BrowseTool")
     
     $RunButton       = $window.FindName("RunButton")
+    $HelpButton      = $window.FindName("HelpButton")
     $ClearButton     = $window.FindName("ClearButton")
     $ExitButton      = $window.FindName("ExitButton")
 
@@ -274,8 +275,9 @@ function Show-IntuneWinAppUtilGUI {
     # Force download the IntuneWinAppUtil.exe tool
     $DownloadTool.Add_Click({
         $confirm = [System.Windows.MessageBox]::Show(
-            "This will download the latest IntuneWinAppUtil.exe and replace (if already exists) the one in your bin folder.`n`nProceed?",
-            "Confirm force download",
+            $window,
+            "Download the latest IntuneWinAppUtil.exe now?`n`nIf a cached copy already exists in the local bin folder, it will be replaced.",
+            "Refresh IntuneWinAppUtil.exe",
             [System.Windows.MessageBoxButton]::YesNo,
             [System.Windows.MessageBoxImage]::Question
         )
@@ -287,6 +289,7 @@ function Show-IntuneWinAppUtilGUI {
             Show-ToolVersion -Path $newPath -Target $ToolVersionText
 
             [System.Windows.MessageBox]::Show(
+                $window,
                 "IntuneWinAppUtil.exe has been refreshed.`n`nPath:`n$newPath",
                 "Download complete",
                 [System.Windows.MessageBoxButton]::OK,
@@ -294,6 +297,7 @@ function Show-IntuneWinAppUtilGUI {
             )
         } catch {
             [System.Windows.MessageBox]::Show(
+                $window,
                 "Download failed:`n$($_.Exception.Message)",
                 "Error",
                 [System.Windows.MessageBoxButton]::OK,
@@ -385,10 +389,11 @@ function Show-IntuneWinAppUtilGUI {
         }
         if ($o.Length -gt $PathLengthLimit) { $pathWarnings += "Output folder: $($o.Length)/$PathLengthLimit" }
         if ($pathWarnings.Count -gt 0) {
-            $msg = "One or more paths exceed $PathLengthLimit characters.`n`n" +
+            $msg = "Some paths exceed the recommended $PathLengthLimit character limit.`n`n" +
                    ($pathWarnings -join "`n") +
-                   "`n`nThis can cause IntuneWinAppUtil to fail on Windows.`nProceed anyway?"
+                   "`n`nIntuneWinAppUtil may fail on Windows when paths are too long.`n`nContinue packaging anyway?"
             $confirm = [System.Windows.MessageBox]::Show(
+                $window,
                 $msg,
                 "Path length warning",
                 [System.Windows.MessageBoxButton]::YesNo,
@@ -496,15 +501,16 @@ function Show-IntuneWinAppUtilGUI {
 
                 $fullPath = Join-Path $o $finalName
 
-                $msg = "Package created and renamed to:`n$finalName"
+                $msg = "Package created successfully.`n`nFile:`n$finalName"
                 if ($finalName -ne $newName) {
-                    $msg += "`n(Note: original name '$newName' already existed.)"
+                    $msg += "`n`nNote: '$newName' already existed, so an incremental suffix was added."
                 }
-                $msg += "`n`nOpen folder?"
+                $msg += "`n`nOpen the output folder and select the package?"
 
                 $resp = [System.Windows.MessageBox]::Show(
+                    $window,
                     $msg,
-                    "Success",
+                    "Package created",
                     [System.Windows.MessageBoxButton]::YesNo,
                     [System.Windows.MessageBoxImage]::Information
                 )
@@ -533,6 +539,37 @@ function Show-IntuneWinAppUtilGUI {
         $FinalFilename.Clear()
     })
 
+    # Help button: explain command-line switches and keyboard shortcuts
+    $HelpButton.Add_Click({
+        $helpText = @"
+Command-line switches
+
+Show-IntuneWinAppUtilGUI -ShowVersion
+Shows the installed module version and the latest available version in the header banner.
+
+Show-IntuneWinAppUtilGUI -ForceUpdateBanner
+Simulates an available update banner for testing the notification area.
+
+Show-IntuneWinAppUtilGUI -Diag
+Writes startup and shutdown diagnostics, such as handles, GDI handles and memory usage.
+
+Standard PowerShell switches
+-Verbose and -Debug are preserved when the GUI relaunches itself in STA mode.
+
+Keyboard shortcuts
+Enter: run packaging.
+Esc: ask before closing the window.
+"@
+
+        [System.Windows.MessageBox]::Show(
+            $window,
+            $helpText,
+            "Help",
+            [System.Windows.MessageBoxButton]::OK,
+            [System.Windows.MessageBoxImage]::Information
+        ) | Out-Null
+    })
+
     # Exit button: close the window
     $ExitButton.Add_Click({
         $window.Close()
@@ -543,7 +580,14 @@ function Show-IntuneWinAppUtilGUI {
         param($evtSender, $e)
         switch ($e.Key) {
             'Escape' {
-                if ([System.Windows.MessageBox]::Show("Exit the tool?", "Confirm", "YesNo", "Question") -eq [System.Windows.MessageBoxResult]::Yes) {
+                $confirmExit = [System.Windows.MessageBox]::Show(
+                    $window,
+                    "Close IntuneWinAppUtil GUI?`n`nCurrent field values will not be kept, except the saved IntuneWinAppUtil path.",
+                    "Close IntuneWinAppUtil GUI",
+                    [System.Windows.MessageBoxButton]::YesNo,
+                    [System.Windows.MessageBoxImage]::Question
+                )
+                if ($confirmExit -eq [System.Windows.MessageBoxResult]::Yes) {
                     $window.Close()
                 }
             }

--- a/Public/Show-IntuneWinAppUtilGui.ps1
+++ b/Public/Show-IntuneWinAppUtilGui.ps1
@@ -24,7 +24,9 @@ function Show-IntuneWinAppUtilGUI {
         $modulePath = $MyInvocation.MyCommand.Module.Path
         $shell = if ($PSVersionTable.PSEdition -eq 'Core') { 'pwsh' } else { 'powershell' }
         $cmd = "Import-Module `"$modulePath`"; Show-IntuneWinAppUtilGUI"
-        if ($PSBoundParameters.ContainsKey('Debug')) { $cmd += " -Debug" }
+        foreach ($switchName in @('Diag', 'ShowVersion', 'ForceUpdateBanner', 'Debug', 'Verbose')) {
+            if ($PSBoundParameters.ContainsKey($switchName)) { $cmd += " -$switchName" }
+        }
         Start-Process $shell -ArgumentList @(
             '-NoProfile',
             '-STA',

--- a/Public/Show-IntuneWinAppUtilGui.ps1
+++ b/Public/Show-IntuneWinAppUtilGui.ps1
@@ -146,10 +146,17 @@ function Show-IntuneWinAppUtilGUI {
 
     if ($shouldCheckUpdates) {
         $currentVersion = $MyInvocation.MyCommand.Module.Version
-        if ($ForceUpdateBanner) { $currentVersion = [version]'1.0.0' }
         $modulePath = $MyInvocation.MyCommand.Module.Path
         $moduleName = 'IntuneWinAppUtilGUI'
         $timeoutSeconds = 10
+
+        if ($ForceUpdateBanner) {
+            $UpdateAvailableText.Text = "Update available: test banner (run 'Update-Module IntuneWinAppUtilGUI' in your PowerShell session)"
+            $UpdateAvailableText.Visibility = [System.Windows.Visibility]::Visible
+        } elseif ($ShowVersion) {
+            $UpdateAvailableText.Text = "Installed: $currentVersion | Latest: checking..."
+            $UpdateAvailableText.Visibility = [System.Windows.Visibility]::Visible
+        }
 
         $updateCheckJob = Start-Job -ArgumentList $modulePath, $moduleName, $currentVersion, $timeoutSeconds, [bool]$ShowVersion -ScriptBlock {
             param($modulePath, $moduleName, $currentVersion, $timeoutSeconds, $showVersion)
@@ -192,8 +199,7 @@ function Show-IntuneWinAppUtilGUI {
                 $updateCheckJob = $null
 
                 if ($ForceUpdateBanner) {
-                    $UpdateAvailableText.Text = "Update available: $($latest.Latest) (run 'Update-Module IntuneWinAppUtilGUI' in your PowerShell session)"
-                    $UpdateAvailableText.Visibility = [System.Windows.Visibility]::Visible
+                    return
                 } elseif ($ShowVersion) {
                     $latestText = if ($latest -and $latest.Latest) { $latest.Latest } else { 'unknown' }
                     if ($latest -and $latest.Error) {

--- a/Public/Show-IntuneWinAppUtilGui.ps1
+++ b/Public/Show-IntuneWinAppUtilGui.ps1
@@ -473,7 +473,25 @@ function Show-IntuneWinAppUtilGUI {
                     $counter++
                 }
 
-                Rename-Item -Path $defaultPath -NewName $finalName -Force
+                $renameSucceeded = $false
+                $renameError = $null
+                for ($attempt = 1; $attempt -le 10; $attempt++) {
+                    try {
+                        Rename-Item -Path $defaultPath -NewName $finalName -Force
+                        $renameSucceeded = $true
+                        break
+                    } catch {
+                        $renameError = $_.Exception.Message
+                        if ($attempt -lt 10) {
+                            Start-Sleep -Milliseconds (250 * $attempt)
+                        }
+                    }
+                }
+
+                if (-not $renameSucceeded) {
+                    throw "Unable to rename '$defaultPath' to '$finalName' after several attempts. Last error: $renameError"
+                }
+
                 $fullPath = Join-Path $o $finalName
 
                 $msg = "Package created and renamed to:`n$finalName"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This tool simplifies the packaging of Win32 apps for Microsoft Intune by providi
 - Automatically stores tool path and reuses it on next launch (saved in a JSON file, check "[Configuration file](#%EF%B8%8F-configuration-file)").
 - Graphical interface for all required options (`-c`, `-s`, `-o`).
 - **Auto-download** of the latest version of `IntuneWinAppUtil.exe` from GitHub (optional).
-- It detects the use of PSAppDeployToolkit and automatically proposes executable file and final IntuneWin package name.
+- It detects the use of PSAppDeployToolkit and automatically proposes the setup file and final IntuneWin package name, including MSI-backed packages.
 - Sanitizes invalid characters from the output filename.
 - Live path length indicator for Source/Output folders, with a final max-path check at Run time.
 - Optional update check on startup with a non-blocking UI banner.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This tool simplifies the packaging of Win32 apps for Microsoft Intune by providi
 - Graphical interface for all required options (`-c`, `-s`, `-o`).
 - **Auto-download** of the latest version of `IntuneWinAppUtil.exe` from GitHub (optional).
 - It detects the use of PSAppDeployToolkit and automatically proposes the setup file and final IntuneWin package name, including MSI-backed packages.
+- Uses Windows-version-safe UI labels instead of emoji glyphs in the WPF interface.
 - Sanitizes invalid characters from the output filename.
 - Live path length indicator for Source/Output folders, with a final max-path check at Run time.
 - Optional update check on startup with a non-blocking UI banner.
@@ -109,19 +110,6 @@ If the path to `IntuneWinAppUtil.exe` is not provided:
 - Clear and Exit buttons are provided to reset inputs or close the app manually.
 - Use `Show-IntuneWinAppUtilGUI -ShowVersion` to display installed/latest versions for testing.
 - Use `Show-IntuneWinAppUtilGUI -ForceUpdateBanner` to simulate an update banner.
-
----
-
-## 🐞 Known Issues
-
-### Emoji rendering on Windows 10 (and earlier versions)
-
-The graphical interface makes use of emojis (such as ✅, 🚀, 🔧, etc.) to improve visual feedback and usability.  
-**On Windows 10** (also 8.1 and 7), some emojis might not be displayed correctly due to limited font support in the system’s default rendering engine. You may see missing characters or fallback symbols instead. **On Windows 11**, emoji rendering is fully supported and works as expected.
-
-> [!IMPORTANT]  
-> This is only a cosmetic issue. The script and tool functionality are not affected in any way. Everything will continue to work normally on both Windows 10 and Windows 11.
-> If you would like to help me fix this problem, feel free to open a Pull Request with your integration!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,24 @@ If the path to `IntuneWinAppUtil.exe` is not provided:
 
 ## 💡 Tips
 
-- Press **ESC** to close the window.
+- Use the **Help** button in the main window to review command-line switches and keyboard shortcuts.
+- Press **ESC** to close the window after confirmation.
 - Press **ENTER** to run the packaging when you are ready.
 - A small tooltip message at the bottom of the GUI provides quick usage hints.
 - Clear and Exit buttons are provided to reset inputs or close the app manually.
-- Use `Show-IntuneWinAppUtilGUI -ShowVersion` to display installed/latest versions for testing.
-- Use `Show-IntuneWinAppUtilGUI -ForceUpdateBanner` to simulate an update banner.
+
+### Optional launch switches
+
+```powershell
+Show-IntuneWinAppUtilGUI -ShowVersion
+Show-IntuneWinAppUtilGUI -ForceUpdateBanner
+Show-IntuneWinAppUtilGUI -Diag
+```
+
+- `-ShowVersion` displays installed/latest module versions in the header banner.
+- `-ForceUpdateBanner` simulates an update banner for testing.
+- `-Diag` writes startup/shutdown diagnostics such as handles, GDI handles and memory usage.
+- Standard PowerShell `-Verbose` and `-Debug` switches are preserved when the GUI relaunches itself in STA mode.
 
 ---
 

--- a/UI/UI.xaml
+++ b/UI/UI.xaml
@@ -394,7 +394,6 @@
 
                     <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <Button Name="RunButton" Content="Run" Style="{StaticResource PrimaryButtonStyle}" Margin="0,0,8,0"/>
-                        <Button Name="HelpButton" Content="Help" Width="82" Margin="0,0,8,0"/>
                         <Button Name="ClearButton" Content="Clear" Width="104" Margin="0,0,8,0"/>
                         <Button Name="ExitButton" Content="Exit (ESC)" Style="{StaticResource DangerButtonStyle}"/>
                     </StackPanel>
@@ -406,6 +405,10 @@
                            Margin="0,10,0,0"
                            Foreground="{StaticResource MutedBrush}">
                     <Run Text="Gioxx, 2026 - " />
+                    <Hyperlink Name="HelpButton" ToolTip="Show command-line switches and keyboard shortcuts">
+                        Help
+                    </Hyperlink>
+                    <Run Text=" - " />
                     <Hyperlink NavigateUri="https://github.com/gioxx/IntuneWinAppUtilGUI">
                         Available on GitHub
                     </Hyperlink>

--- a/UI/UI.xaml
+++ b/UI/UI.xaml
@@ -82,7 +82,7 @@
                 </Grid>
 
                 <TextBlock
-                    Text="Remember that the setup file must be a valid MSI or EXE file.&#x0a;If I detect the existence of Invoke-AppDeployToolkit.exe in the source folder, I propose it as the default setup file. When the package is MSI-based, I can also use the MSI metadata to suggest the final filename."
+                    Text="Setup file must be a valid MSI or EXE. PSADT packages are detected automatically; MSI metadata is used when script metadata is missing."
                     Foreground="Gray"
                     FontSize="12"
                     Margin="0,5,0,0"
@@ -145,7 +145,7 @@
                 <TextBox Name="FinalFilename" Margin="0,5" Padding="4"/>
 
                 <TextBlock
-                    Text="If I detect the existence of Invoke-AppDeployToolkit.ps1 in the source folder, I propose a default name based on the application name and version extracted from the script. If those values are missing, I fall back to the MSI metadata when available."
+                    Text="Suggested from PSADT AppName/AppVersion, or from MSI metadata when those values are empty."
                     Foreground="Gray"
                     FontSize="12"
                     Margin="0,5,0,0"
@@ -162,20 +162,20 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
-                <Button Name="RunButton" Content="🚀 Run" Width="100" Height="30" Grid.Column="0" Padding="2"/>
-                <Button Name="ClearButton" Content="🧽 Clear" Width="100" Height="30" Grid.Column="2" Padding="2"/>
-                <Button Name="ExitButton" Content="🚪 Exit" Width="100" Height="30" Grid.Column="4" Padding="2"/>
+                <Button Name="RunButton" Content="Run" Width="100" Height="30" Grid.Column="0" Padding="2"/>
+                <Button Name="ClearButton" Content="Clear" Width="100" Height="30" Grid.Column="2" Padding="2"/>
+                <Button Name="ExitButton" Content="Exit" Width="100" Height="30" Grid.Column="4" Padding="2"/>
             </Grid>
 
             <!-- Info tooltip -->
             <TextBlock Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
-            Text="⚠️ Source folder, setup file and output folder are required (*).&#x0a;ℹ️ The Source folder path length shown above is indicative; the final check runs at packaging time (Run) and considers the longest file path.&#x0a;ℹ️ Final filename is optional and used for renaming the .intunewin file. If not provided, the tool will generate a name based on the source folder.&#x0a;ℹ️ IntuneWinAppUtil Path is also optional. If not provided, the tool will automatically download the latest version from GitHub.&#x0a;&#x0a;Press ESC on the keyboard to close the application.&#x0a;Click on 'Run' button or press ENTER on the keyboard to execute the IntuneWinAppUtil with the provided parameters."
+            Text="Required: Source folder, setup file and output folder (*).&#x0a;Source path length is indicative; Run checks the longest file path before packaging.&#x0a;Final filename is optional. If empty, the tool uses the source folder name.&#x0a;IntuneWinAppUtil Path is optional; if empty, the latest tool is downloaded automatically.&#x0a;&#x0a;Press ESC to close. Click Run or press ENTER to execute IntuneWinAppUtil."
             Foreground="Gray" FontSize="12" Margin="0,20,0,0" TextWrapping="Wrap"/>
 
             <!-- GitHub Link -->
             <TextBlock Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
                     HorizontalAlignment="Right" FontSize="11" Margin="0,6,0,0">
-                <Run Text="Gioxx, 2025 ❤️ " />
+                <Run Text="Gioxx, 2025 " />
                 <Hyperlink NavigateUri="https://github.com/gioxx/IntuneWinAppUtilGUI">
                     Available on GitHub
                 </Hyperlink>

--- a/UI/UI.xaml
+++ b/UI/UI.xaml
@@ -1,185 +1,378 @@
 <Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="IntuneWinAppUtil GUI · 1.0.8"
+        Title="IntuneWinAppUtil GUI - 1.0.8"
         SizeToContent="WidthAndHeight"
         ResizeMode="CanResize"
         MinWidth="700"
-        MinHeight="360"
-        WindowStartupLocation="CenterScreen">
+        MinHeight="420"
+        WindowStartupLocation="CenterScreen"
+        Background="#F4F7FB"
+        FontFamily="Segoe UI"
+        TextOptions.TextFormattingMode="Ideal"
+        TextOptions.TextRenderingMode="ClearType">
 
-    <DockPanel Margin="15">
+    <Window.Resources>
+        <SolidColorBrush x:Key="InkBrush" Color="#182230"/>
+        <SolidColorBrush x:Key="MutedBrush" Color="#667085"/>
+        <SolidColorBrush x:Key="LineBrush" Color="#D7DEE8"/>
+        <SolidColorBrush x:Key="PanelBrush" Color="#FFFFFF"/>
+        <SolidColorBrush x:Key="SoftPanelBrush" Color="#F8FAFC"/>
+        <SolidColorBrush x:Key="AccentBrush" Color="#0B6BD3"/>
+        <SolidColorBrush x:Key="AccentDarkBrush" Color="#084B93"/>
 
-        <!-- ===== Header ===== -->
-        <Border DockPanel.Dock="Top" Padding="0,0,0,12">
-            <StackPanel Orientation="Vertical">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <Image Name="HeaderIcon" Width="28" Height="28" Margin="0,0,8,0"/>
-                    <TextBlock Text="IntuneWinAppUtil GUI"
-                               FontSize="24" FontWeight="Bold"
-                               VerticalAlignment="Center"
-                               TextOptions.TextFormattingMode="Ideal"
-                               TextOptions.TextRenderingMode="ClearType"/>
-                    <!-- <TextBlock Text="  ·  1.0.0"
-                               FontSize="18" Foreground="Gray"
-                               VerticalAlignment="Center" Margin="6,2,0,0"/> -->
-                </StackPanel>
-                <TextBlock Name="UpdateAvailableText"
-                           Text=""
-                           Foreground="Gray"
-                           FontSize="12"
-                           Margin="36,4,0,0"
-                           Visibility="Collapsed"/>
-            </StackPanel>
-        </Border>
-        <!-- ===== End Header ===== -->
+        <Style TargetType="Label">
+            <Setter Property="Foreground" Value="{StaticResource InkBrush}"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Margin" Value="0,3,0,0"/>
+            <Setter Property="VerticalAlignment" Value="Top"/>
+        </Style>
 
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/> <!-- 0 Source -->
-                <RowDefinition Height="Auto"/> <!-- 1 Setup -->
-                <RowDefinition Height="Auto"/> <!-- 2 Output -->
-                <RowDefinition Height="Auto"/> <!-- 3 Tool Path -->
-                <RowDefinition Height="Auto"/> <!-- 4 Final filename -->
-                <RowDefinition Height="Auto"/> <!-- 5 Run -->
-                <RowDefinition Height="Auto"/> <!-- 6 Tooltip -->
-                <RowDefinition Height="Auto"/> <!-- 7 GitHub link -->
-            </Grid.RowDefinitions>
+        <Style TargetType="TextBox">
+            <Setter Property="MinHeight" Value="31"/>
+            <Setter Property="Padding" Value="8,5"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Background" Value="#FFFFFF"/>
+            <Setter Property="BorderBrush" Value="#C9D4E5"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Foreground" Value="{StaticResource InkBrush}"/>
+            <Setter Property="FontSize" Value="12.5"/>
+        </Style>
 
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="150"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
+        <Style TargetType="Button">
+            <Setter Property="MinHeight" Value="31"/>
+            <Setter Property="Padding" Value="12,5"/>
+            <Setter Property="Background" Value="#FFFFFF"/>
+            <Setter Property="BorderBrush" Value="#B9C7DA"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Foreground" Value="{StaticResource InkBrush}"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="ButtonChrome"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="6">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              RecognizesAccessKey="True"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="ButtonChrome" Property="Background" Value="#EEF6FF"/>
+                                <Setter TargetName="ButtonChrome" Property="BorderBrush" Value="#7FB3EA"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="ButtonChrome" Property="Background" Value="#DDEEFF"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="ButtonChrome" Property="Opacity" Value="0.55"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
 
-            <!-- Source Folder -->
-            <Label Grid.Row="0" Grid.Column="0" Content="* Source Folder (-c):" VerticalAlignment="Top" Margin="0,5"/>
-            <StackPanel Grid.Row="0" Grid.Column="1" Margin="0,5" MinHeight="35">
+        <Style x:Key="PrimaryButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="{StaticResource AccentBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource AccentDarkBrush}"/>
+            <Setter Property="Foreground" Value="#FFFFFF"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="MinHeight" Value="34"/>
+            <Setter Property="Width" Value="104"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="PrimaryButtonChrome"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="1"
+                                CornerRadius="6">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              RecognizesAccessKey="True"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="PrimaryButtonChrome" Property="Background" Value="#084B93"/>
+                                <Setter TargetName="PrimaryButtonChrome" Property="BorderBrush" Value="#063F7D"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="PrimaryButtonChrome" Property="Background" Value="#063F7D"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="PrimaryButtonChrome" Property="Opacity" Value="0.55"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="DangerButtonStyle" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+            <Setter Property="Background" Value="#FFF7F7"/>
+            <Setter Property="BorderBrush" Value="#D1A0A0"/>
+            <Setter Property="Foreground" Value="#9F2424"/>
+            <Setter Property="Width" Value="104"/>
+        </Style>
+
+        <Style x:Key="HelpTextStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource MutedBrush}"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Margin" Value="0,5,0,0"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="MaxWidth" Value="510"/>
+        </Style>
+
+        <Style x:Key="SectionTitleStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource InkBrush}"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Margin" Value="0,0,0,10"/>
+        </Style>
+    </Window.Resources>
+
+    <Border Margin="14"
+            Background="{StaticResource PanelBrush}"
+            BorderBrush="{StaticResource LineBrush}"
+            BorderThickness="1"
+            CornerRadius="10">
+        <Border.Effect>
+            <DropShadowEffect BlurRadius="18" ShadowDepth="0" Opacity="0.14" Color="#334155"/>
+        </Border.Effect>
+
+        <DockPanel LastChildFill="True">
+            <!-- Header -->
+            <Border DockPanel.Dock="Top" CornerRadius="10,10,0,0" Padding="18,16">
+                <Border.Background>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                        <GradientStop Color="#071C33" Offset="0"/>
+                        <GradientStop Color="#0B4F9C" Offset="0.58"/>
+                        <GradientStop Color="#17A2B8" Offset="1"/>
+                    </LinearGradientBrush>
+                </Border.Background>
+
                 <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Border Width="42" Height="42" CornerRadius="9" Background="#1AFFFFFF" BorderBrush="#33FFFFFF" BorderThickness="1">
+                        <Image Name="HeaderIcon" Width="28" Height="28" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+
+                    <StackPanel Grid.Column="1" Margin="12,0,0,0" VerticalAlignment="Center">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="IntuneWinAppUtil GUI"
+                                       FontSize="23"
+                                       FontWeight="SemiBold"
+                                       Foreground="#FFFFFF"
+                                       VerticalAlignment="Center"/>
+                            <Border Margin="10,2,0,0" Padding="7,2" CornerRadius="9" Background="#24FFFFFF" BorderBrush="#3DFFFFFF" BorderThickness="1">
+                                <TextBlock Text="1.0.8" Foreground="#FFFFFF" FontSize="11" FontWeight="SemiBold"/>
+                            </Border>
+                        </StackPanel>
+                        <TextBlock Text="Win32 packaging assistant for Microsoft Intune"
+                                   Foreground="#CDE8FF"
+                                   FontSize="12"
+                                   Margin="0,2,0,0"/>
+                        <TextBlock Name="UpdateAvailableText"
+                                   Text=""
+                                   Foreground="#CDE8FF"
+                                   FontSize="12"
+                                   Margin="0,5,0,0"
+                                   Visibility="Collapsed"/>
+                    </StackPanel>
+
+                    <Border Grid.Column="2" Padding="10,5" CornerRadius="12" Background="#1F000000" BorderBrush="#2DFFFFFF" BorderThickness="1" VerticalAlignment="Center">
+                        <TextBlock Text="Package - Validate - Export" Foreground="#EAF6FF" FontSize="11" FontWeight="SemiBold"/>
+                    </Border>
+                </Grid>
+            </Border>
+
+            <Grid Margin="18">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <!-- Package inputs -->
+                <Border Grid.Row="0"
+                        Background="{StaticResource SoftPanelBrush}"
+                        BorderBrush="{StaticResource LineBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="14">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="150"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Text="Package source" Style="{StaticResource SectionTitleStyle}"/>
+
+                        <Label Grid.Row="1" Grid.Column="0" Content="* Source Folder (-c):"/>
+                        <StackPanel Grid.Row="1" Grid.Column="1" Margin="0,0,0,10" MinHeight="35">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Name="SourceFolder" Grid.Column="0" Margin="0,0,10,0"/>
+                                <Button Name="BrowseSource" Content="Browse..." Grid.Column="1" Width="88"/>
+                            </Grid>
+                            <TextBlock Name="SourceFolderPathLength"
+                                       Text="Path length: 0/260"
+                                       Foreground="{StaticResource MutedBrush}"
+                                       FontSize="11"
+                                       Margin="0,4,0,0"
+                                       Visibility="Collapsed"/>
+                        </StackPanel>
+
+                        <Label Grid.Row="2" Grid.Column="0" Content="* Setup File (-s):"/>
+                        <StackPanel Grid.Row="2" Grid.Column="1" Margin="0,0,0,10" MinHeight="35">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Name="SetupFile" Grid.Column="0" Margin="0,0,10,0"/>
+                                <Button Name="BrowseSetup" Content="Browse..." Grid.Column="1" Width="88"/>
+                            </Grid>
+                            <TextBlock
+                                Text="Valid MSI or EXE. PSADT packages are detected automatically; MSI metadata is used when script metadata is missing."
+                                Style="{StaticResource HelpTextStyle}"/>
+                        </StackPanel>
+
+                        <Label Grid.Row="3" Grid.Column="0" Content="* Output Folder (-o):"/>
+                        <StackPanel Grid.Row="3" Grid.Column="1" MinHeight="35">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Name="OutputFolder" Grid.Column="0" Margin="0,0,10,0"/>
+                                <Button Name="BrowseOutput" Content="Browse..." Grid.Column="1" Width="88"/>
+                            </Grid>
+                            <TextBlock Name="OutputFolderPathLength"
+                                       Text="Path length: 0/260"
+                                       Foreground="{StaticResource MutedBrush}"
+                                       FontSize="11"
+                                       Margin="0,4,0,0"
+                                       Visibility="Collapsed"/>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Tool and output options -->
+                <Border Grid.Row="1"
+                        Margin="0,12,0,0"
+                        Background="#FFFFFF"
+                        BorderBrush="{StaticResource LineBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="14">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="150"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Text="Tool and output" Style="{StaticResource SectionTitleStyle}"/>
+
+                        <Label Grid.Row="1" Grid.Column="0" Content="IntuneWinAppUtil Path:"/>
+                        <StackPanel Grid.Row="1" Grid.Column="1" Margin="0,0,0,10" MinHeight="50">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+
+                                <TextBox Name="ToolPathBox" Grid.Column="0" Margin="0,0,10,0" HorizontalScrollBarVisibility="Auto"/>
+                                <Button Name="BrowseTool" Content="Browse..." Grid.Column="1" Width="88" Margin="0,0,10,0"/>
+                                <Button Name="DownloadTool" Content="Force download" Grid.Column="2" Width="118"/>
+                            </Grid>
+
+                            <TextBlock Margin="0,5,0,0" Foreground="{StaticResource MutedBrush}" FontSize="12" TextWrapping="Wrap" MaxWidth="510">
+                                <Run Name="ToolVersionText" Text="IntuneWinAppUtil version: (not detected)"/>
+                                <Run Text=" (" />
+                                <Hyperlink NavigateUri="https://github.com/gioxx/IntuneWinAppUtilGUI/blob/main/Tools/IntuneWinAppUtilVersions.md" ToolTip="Open versions list page">Version history</Hyperlink>
+                                <Run Text=")" />
+                            </TextBlock>
+
+                            <TextBlock
+                                Text="Leave empty to download the latest tool automatically, or choose a specific executable."
+                                Style="{StaticResource HelpTextStyle}"/>
+                        </StackPanel>
+
+                        <Label Grid.Row="2" Grid.Column="0" Content="Final filename:"/>
+                        <StackPanel Grid.Row="2" Grid.Column="1" MinHeight="35">
+                            <TextBox Name="FinalFilename"/>
+                            <TextBlock
+                                Text="Suggested from PSADT AppName/AppVersion, or from MSI metadata when those values are empty."
+                                Style="{StaticResource HelpTextStyle}"/>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Actions and guidance -->
+                <Grid Grid.Row="2" Margin="0,14,0,0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <TextBox Name="SourceFolder" Grid.Column="0" Margin="0,0,10,0" Padding="4"/>
-                    <Button Name="BrowseSource" Content="Browse..." Grid.Column="1" Width="80" Padding="2"/>
+
+                    <Border Grid.Column="0" Background="#EEF6FF" BorderBrush="#C5DCF6" BorderThickness="1" CornerRadius="8" Padding="12">
+                        <TextBlock
+                            Text="Required: Source folder, setup file and output folder (*). Source path length is indicative; Run checks the longest file path before packaging. Final filename is optional. Press ESC to close."
+                            Foreground="#33536F"
+                            FontSize="12"
+                            TextWrapping="Wrap"
+                            MaxWidth="400"/>
+                    </Border>
+
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="14,0,0,0">
+                        <Button Name="RunButton" Content="Run" Style="{StaticResource PrimaryButtonStyle}" Margin="0,0,8,0"/>
+                        <Button Name="ClearButton" Content="Clear" Width="104" Margin="0,0,8,0"/>
+                        <Button Name="ExitButton" Content="Exit" Style="{StaticResource DangerButtonStyle}"/>
+                    </StackPanel>
                 </Grid>
-                <TextBlock Name="SourceFolderPathLength"
-                           Text="Path length: 0/260"
-                           Foreground="Gray"
+
+                <TextBlock Grid.Row="3"
+                           HorizontalAlignment="Right"
                            FontSize="11"
-                           Margin="0,4,0,0"
-                           Visibility="Collapsed"/>
-            </StackPanel>
-
-            <!-- Setup File -->
-            <Label Grid.Row="1" Grid.Column="0" Content="* Setup File (-s):" VerticalAlignment="Top" Margin="0,5"/>
-            <StackPanel Grid.Row="1" Grid.Column="1" Margin="0,5" MinHeight="35">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBox Name="SetupFile" Grid.Column="0" Margin="0,0,10,0" Padding="4"/>
-                    <Button Name="BrowseSetup" Content="Browse..." Grid.Column="1" Width="80" Padding="2"/>
-                </Grid>
-
-                <TextBlock
-                    Text="Setup file must be a valid MSI or EXE. PSADT packages are detected automatically; MSI metadata is used when script metadata is missing."
-                    Foreground="Gray"
-                    FontSize="12"
-                    Margin="0,5,0,0"
-                    TextWrapping="Wrap"/>
-            </StackPanel>
-
-            <!-- Output Folder -->
-            <Label Grid.Row="2" Grid.Column="0" Content="* Output Folder (-o):" VerticalAlignment="Top" Margin="0,5"/>
-            <StackPanel Grid.Row="2" Grid.Column="1" Margin="0,5" MinHeight="35">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBox Name="OutputFolder" Grid.Column="0" Margin="0,0,10,0" Padding="4"/>
-                    <Button Name="BrowseOutput" Content="Browse..." Grid.Column="1" Width="80" Padding="2"/>
-                </Grid>
-                <TextBlock Name="OutputFolderPathLength"
-                           Text="Path length: 0/260"
-                           Foreground="Gray"
-                           FontSize="11"
-                           Margin="0,4,0,0"
-                           Visibility="Collapsed"/>
-            </StackPanel>
-
-            <!-- Tool Path -->
-            <Label Grid.Row="3" Grid.Column="0" Content="  IntuneWinAppUtil Path:" VerticalAlignment="Top" Margin="0,5"/>
-            <StackPanel Grid.Row="3" Grid.Column="1" Margin="0,5" MinHeight="50">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-
-                <TextBox Name="ToolPathBox" Grid.Column="0" Margin="0,0,10,0" Padding="4" HorizontalScrollBarVisibility="Auto"/>
-                <Button Name="BrowseTool" Content="Browse..." Grid.Column="1" Width="90" Padding="2" Margin="0,0,10,0"/>
-                <Button Name="DownloadTool" Content="Force download" Grid.Column="2" Width="110" Padding="2"/>
+                           Margin="0,10,0,0"
+                           Foreground="{StaticResource MutedBrush}">
+                    <Run Text="Gioxx, 2025 " />
+                    <Hyperlink NavigateUri="https://github.com/gioxx/IntuneWinAppUtilGUI">
+                        Available on GitHub
+                    </Hyperlink>
+                </TextBlock>
             </Grid>
-
-            <!-- Version line with static link -->
-            <TextBlock Margin="0,5,0,0" Foreground="Gray" FontSize="12" TextWrapping="Wrap">
-                <Run Name="ToolVersionText" Text="IntuneWinAppUtil version: (not detected)"/>
-                <Run Text=" (" />
-                <Hyperlink NavigateUri="https://github.com/gioxx/IntuneWinAppUtilGUI/blob/main/Tools/IntuneWinAppUtilVersions.md" ToolTip="Open versions list page">Version history</Hyperlink>
-                <Run Text=")" />
-            </TextBlock>
-
-            <TextBlock
-                Text="If you want to use a specific version, please specify the path to the executable.&#x0a;You can also not specify (or search for) the path to the executable. If not specified, the latest version of the tool will be downloaded and the field will be automatically filled in.&#x0a;You can also use, at any time, the 'Force download' button to download the latest available version from GitHub."
-                Foreground="Gray"
-                FontSize="12"
-                Margin="0,5,0,0"
-                TextWrapping="Wrap"/>
-            </StackPanel>
-
-            <!-- Final Filename -->
-            <Label Grid.Row="4" Grid.Column="0" Content="  Final filename:" VerticalAlignment="Top" Margin="0,5"/>
-            <StackPanel Grid.Row="4" Grid.Column="1" Margin="0,5" MinHeight="35">
-                <TextBox Name="FinalFilename" Margin="0,5" Padding="4"/>
-
-                <TextBlock
-                    Text="Suggested from PSADT AppName/AppVersion, or from MSI metadata when those values are empty."
-                    Foreground="Gray"
-                    FontSize="12"
-                    Margin="0,5,0,0"
-                    TextWrapping="Wrap"/>
-            </StackPanel>
-
-            <!-- Buttons -->
-            <Grid Grid.Row="5" Grid.Column="1" Margin="0,10,0,0">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="10"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="10"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-
-                <Button Name="RunButton" Content="Run" Width="100" Height="30" Grid.Column="0" Padding="2"/>
-                <Button Name="ClearButton" Content="Clear" Width="100" Height="30" Grid.Column="2" Padding="2"/>
-                <Button Name="ExitButton" Content="Exit" Width="100" Height="30" Grid.Column="4" Padding="2"/>
-            </Grid>
-
-            <!-- Info tooltip -->
-            <TextBlock Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
-            Text="Required: Source folder, setup file and output folder (*).&#x0a;Source path length is indicative; Run checks the longest file path before packaging.&#x0a;Final filename is optional. If empty, the tool uses the source folder name.&#x0a;IntuneWinAppUtil Path is optional; if empty, the latest tool is downloaded automatically.&#x0a;&#x0a;Press ESC to close. Click Run or press ENTER to execute IntuneWinAppUtil."
-            Foreground="Gray" FontSize="12" Margin="0,20,0,0" TextWrapping="Wrap"/>
-
-            <!-- GitHub Link -->
-            <TextBlock Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
-                    HorizontalAlignment="Right" FontSize="11" Margin="0,6,0,0">
-                <Run Text="Gioxx, 2025 " />
-                <Hyperlink NavigateUri="https://github.com/gioxx/IntuneWinAppUtilGUI">
-                    Available on GitHub
-                </Hyperlink>
-            </TextBlock>
-        </Grid>
-    </DockPanel>
+        </DockPanel>
+    </Border>
 </Window>

--- a/UI/UI.xaml
+++ b/UI/UI.xaml
@@ -373,21 +373,29 @@
                             BorderThickness="1"
                             CornerRadius="8"
                             Padding="12"
-                            HorizontalAlignment="Left">
+                            HorizontalAlignment="Stretch"
+                            Margin="0,0,12,0">
                         <TextBlock
-                            Text="Required: Source folder, setup file and output folder (*). Source path length is indicative; Run checks the longest file path before packaging. Final filename is optional. Press ESC to close."
                             Foreground="#33536F"
                             FontSize="12"
                             TextWrapping="Wrap"
-                            MaxWidth="400"
+                            MaxWidth="520"
                             HorizontalAlignment="Left"
-                            TextAlignment="Left"/>
+                            TextAlignment="Left">
+                            <Run Text="Required: Source folder, setup file and output folder(*)" FontWeight="SemiBold"/>
+                            <LineBreak/>
+                            <Run Text="Source path length is indicative; Run checks the longest file path before packaging."/>
+                            <LineBreak/>
+                            <Run Text="Final filename is optional. If empty, the tool uses the source folder name."/>
+                            <LineBreak/>
+                            <Run Text="IntuneWinAppUtil Path is optional; if empty, the latest tool is downloaded automatically."/>
+                        </TextBlock>
                     </Border>
 
-                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="14,0,0,0">
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <Button Name="RunButton" Content="Run" Style="{StaticResource PrimaryButtonStyle}" Margin="0,0,8,0"/>
                         <Button Name="ClearButton" Content="Clear" Width="104" Margin="0,0,8,0"/>
-                        <Button Name="ExitButton" Content="Exit" Style="{StaticResource DangerButtonStyle}"/>
+                        <Button Name="ExitButton" Content="Exit (ESC)" Style="{StaticResource DangerButtonStyle}"/>
                     </StackPanel>
                 </Grid>
 

--- a/UI/UI.xaml
+++ b/UI/UI.xaml
@@ -394,6 +394,7 @@
 
                     <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <Button Name="RunButton" Content="Run" Style="{StaticResource PrimaryButtonStyle}" Margin="0,0,8,0"/>
+                        <Button Name="HelpButton" Content="Help" Width="82" Margin="0,0,8,0"/>
                         <Button Name="ClearButton" Content="Clear" Width="104" Margin="0,0,8,0"/>
                         <Button Name="ExitButton" Content="Exit (ESC)" Style="{StaticResource DangerButtonStyle}"/>
                     </StackPanel>
@@ -404,7 +405,7 @@
                            FontSize="11"
                            Margin="0,10,0,0"
                            Foreground="{StaticResource MutedBrush}">
-                    <Run Text="Gioxx, 2026 " />
+                    <Run Text="Gioxx, 2026 - " />
                     <Hyperlink NavigateUri="https://github.com/gioxx/IntuneWinAppUtilGUI">
                         Available on GitHub
                     </Hyperlink>

--- a/UI/UI.xaml
+++ b/UI/UI.xaml
@@ -1,6 +1,6 @@
 <Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="IntuneWinAppUtil GUI · 1.0.7"
+        Title="IntuneWinAppUtil GUI · 1.0.8"
         SizeToContent="WidthAndHeight"
         ResizeMode="CanResize"
         MinWidth="700"

--- a/UI/UI.xaml
+++ b/UI/UI.xaml
@@ -82,7 +82,7 @@
                 </Grid>
 
                 <TextBlock
-                    Text="Remember that the setup file must be a valid MSI or EXE file.&#x0a;If I detect the existence of Invoke-AppDeployToolkit.exe in the source folder, I propose it as the default setup file, making life easier for those who use PSAppDeployToolkit."
+                    Text="Remember that the setup file must be a valid MSI or EXE file.&#x0a;If I detect the existence of Invoke-AppDeployToolkit.exe in the source folder, I propose it as the default setup file. When the package is MSI-based, I can also use the MSI metadata to suggest the final filename."
                     Foreground="Gray"
                     FontSize="12"
                     Margin="0,5,0,0"
@@ -145,7 +145,7 @@
                 <TextBox Name="FinalFilename" Margin="0,5" Padding="4"/>
 
                 <TextBlock
-                    Text="If I detect the existence of Invoke-AppDeployToolkit.ps1 in the source folder, I propose a default name based on the application name and version extracted from the script."
+                    Text="If I detect the existence of Invoke-AppDeployToolkit.ps1 in the source folder, I propose a default name based on the application name and version extracted from the script. If those values are missing, I fall back to the MSI metadata when available."
                     Foreground="Gray"
                     FontSize="12"
                     Margin="0,5,0,0"

--- a/UI/UI.xaml
+++ b/UI/UI.xaml
@@ -130,6 +130,8 @@
             <Setter Property="Margin" Value="0,5,0,0"/>
             <Setter Property="TextWrapping" Value="Wrap"/>
             <Setter Property="MaxWidth" Value="510"/>
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+            <Setter Property="TextAlignment" Value="Left"/>
         </Style>
 
         <Style x:Key="SectionTitleStyle" TargetType="TextBlock">
@@ -178,8 +180,21 @@
                                        FontWeight="SemiBold"
                                        Foreground="#FFFFFF"
                                        VerticalAlignment="Center"/>
-                            <Border Margin="10,2,0,0" Padding="7,2" CornerRadius="9" Background="#24FFFFFF" BorderBrush="#3DFFFFFF" BorderThickness="1">
-                                <TextBlock Text="1.0.8" Foreground="#FFFFFF" FontSize="11" FontWeight="SemiBold"/>
+                            <Border Margin="10,0,0,0"
+                                    Width="48"
+                                    Height="22"
+                                    CornerRadius="11"
+                                    Background="#24FFFFFF"
+                                    BorderBrush="#3DFFFFFF"
+                                    BorderThickness="1"
+                                    VerticalAlignment="Center">
+                                <TextBlock Text="1.0.8"
+                                           Foreground="#FFFFFF"
+                                           FontSize="11"
+                                           FontWeight="SemiBold"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Center"/>
                             </Border>
                         </StackPanel>
                         <TextBlock Text="Win32 packaging assistant for Microsoft Intune"
@@ -317,7 +332,13 @@
                                 <Button Name="DownloadTool" Content="Force download" Grid.Column="2" Width="118"/>
                             </Grid>
 
-                            <TextBlock Margin="0,5,0,0" Foreground="{StaticResource MutedBrush}" FontSize="12" TextWrapping="Wrap" MaxWidth="510">
+                            <TextBlock Margin="0,5,0,0"
+                                       Foreground="{StaticResource MutedBrush}"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       MaxWidth="510"
+                                       HorizontalAlignment="Left"
+                                       TextAlignment="Left">
                                 <Run Name="ToolVersionText" Text="IntuneWinAppUtil version: (not detected)"/>
                                 <Run Text=" (" />
                                 <Hyperlink NavigateUri="https://github.com/gioxx/IntuneWinAppUtilGUI/blob/main/Tools/IntuneWinAppUtilVersions.md" ToolTip="Open versions list page">Version history</Hyperlink>
@@ -346,13 +367,21 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <Border Grid.Column="0" Background="#EEF6FF" BorderBrush="#C5DCF6" BorderThickness="1" CornerRadius="8" Padding="12">
+                    <Border Grid.Column="0"
+                            Background="#EEF6FF"
+                            BorderBrush="#C5DCF6"
+                            BorderThickness="1"
+                            CornerRadius="8"
+                            Padding="12"
+                            HorizontalAlignment="Left">
                         <TextBlock
                             Text="Required: Source folder, setup file and output folder (*). Source path length is indicative; Run checks the longest file path before packaging. Final filename is optional. Press ESC to close."
                             Foreground="#33536F"
                             FontSize="12"
                             TextWrapping="Wrap"
-                            MaxWidth="400"/>
+                            MaxWidth="400"
+                            HorizontalAlignment="Left"
+                            TextAlignment="Left"/>
                     </Border>
 
                     <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="14,0,0,0">
@@ -367,7 +396,7 @@
                            FontSize="11"
                            Margin="0,10,0,0"
                            Foreground="{StaticResource MutedBrush}">
-                    <Run Text="Gioxx, 2025 " />
+                    <Run Text="Gioxx, 2026 " />
                     <Hyperlink NavigateUri="https://github.com/gioxx/IntuneWinAppUtilGUI">
                         Available on GitHub
                     </Hyperlink>


### PR DESCRIPTION
## Summary

Prepare IntuneWinAppUtilGUI 1.0.8.

This release focuses on packaging reliability, PSADT/MSI metadata handling, Windows-version-safe UI labels, a refreshed main window layout, and clearer in-app guidance.

## Changes

- Retry the final `.intunewin` rename when the output file is temporarily locked by another process or sync client.
- Keep PSADT setup detection on `Invoke-AppDeployToolkit.exe` while also reading MSI metadata from package files when `AppName`/`AppVersion` are empty.
- Improve PSADT metadata parsing for common assignment styles such as `$appName`, `$appVersion`, and `$adtSession.AppName`.
- Replace emoji UI glyphs with Windows-version-safe labels for better Windows 10 compatibility.
- Refresh the main window with a cleaner modern layout while preserving the title, icon, fields, guidance text, and existing control names used by the PowerShell code.
- Polish the main window alignment, footer guidance block, version badge, footer separator/year, and keyboard shortcut labels.
- Add an in-app Help popup from the footer that documents optional launch switches and keyboard shortcuts.
- Clarify confirmation popups for forced tool download, path length warnings, package completion and ESC-based exit.
- Preserve `-Diag`, `-ShowVersion`, `-ForceUpdateBanner`, `-Debug`, and `-Verbose` across the automatic STA relaunch.
- Restore immediate feedback for `-ShowVersion` and `-ForceUpdateBanner` in the refreshed header banner.
- Update README usage notes for the Help button and optional launch switches.
- Bump module/UI version to `1.0.8`.

## Validation

- Imported the module with `Import-Module .\IntuneWinAppUtilGUI.psm1 -Force`.
- Parsed `UI\UI.xaml` with `Windows.Markup.XamlReader`.
- Verified the runtime controls used by `Show-IntuneWinAppUtilGUI` are still present after the UI refresh, including the footer `HelpButton` link.
- Verified the exposed `Show-IntuneWinAppUtilGUI` parameters.
- Verified `-ShowVersion` and `-ForceUpdateBanner` update the refreshed header banner immediately.
- Verified PSADT metadata suggestion with a minimal local package fixture.

## Notes before merge

- PR is intentionally still draft while local GUI tests are completed.
- Manual visual/packaging testing should be completed before merging into `main`.

Fixes #7
Fixes #8
Fixes #16